### PR TITLE
feat(ci-cd): improve CI/CD: backend, frontend, deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,22 @@
-name: CI
+name: CI/CD
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
     branches: [main, develop]
 
 jobs:
-  build-and-test:
+  # ============================================
+  # BACKEND — Lint + Tests
+  # ============================================
+  backend-ci:
+    name: Backend CI
     runs-on: ubuntu-latest
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:15-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -26,15 +30,19 @@ jobs:
 
     env:
       DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/test_db"
+      JWT_SECRET: test-jwt-secret-for-ci
+      NODE_ENV: test
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -44,35 +52,96 @@ jobs:
         run: npx prisma generate
         working-directory: ./backend
 
-      - name: Run Prisma Migrate (dev)
+      - name: Run database migrations
         run: npx prisma migrate deploy
         working-directory: ./backend
 
-      - name: Run linter
+      - name: Lint
         run: npm run lint
         working-directory: ./backend
-        continue-on-error: true
 
-      - name: Run prettier
-        run: npm run format
+      - name: Format check
+        run: npx prettier --check "src/**/*.ts" "test/**/*.ts"
         working-directory: ./backend
-        continue-on-error: true
 
-      - name: Run tests
+      - name: Unit tests
         run: npm run test
         working-directory: ./backend
 
-      - name: Run E2E tests
+      - name: E2E tests
         run: npm run test:e2e
         working-directory: ./backend
         env:
-          JWT_SECRET: test-jwt-secret-for-ci
           SMTP_HOST: smtp.test.com
-          SMTP_PORT: 587
+          SMTP_PORT: "587"
           SMTP_USER: test@test.com
           SMTP_PASSWORD: test
           SMTP_FROM: noreply@test.com
 
-      - name: Run tests with coverage
+      - name: Tests with coverage
         run: npm run test:cov
         working-directory: ./backend
+
+  # ============================================
+  # FRONTEND — Lint + Tests
+  # ============================================
+  frontend-ci:
+    name: Frontend CI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install pnpm
+        run: corepack enable && corepack prepare pnpm@latest --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: ./frontend
+
+      - name: Lint
+        run: pnpm run lint
+        working-directory: ./frontend
+
+      - name: Tests
+        run: pnpm run test
+        working-directory: ./frontend
+
+  # ============================================
+  # DEPLOY — Uniquement sur push main
+  # ============================================
+  deploy:
+    name: Deploy to VPS
+    runs-on: ubuntu-latest
+    needs: [backend-ci, frontend-ci]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            cd ${{ secrets.VPS_PROJECT_PATH }}
+
+            echo "=== Pulling latest changes ==="
+            git pull origin main
+
+            echo "=== Building and deploying ==="
+            docker compose build --no-cache
+
+            echo "=== Restarting services ==="
+            docker compose up -d
+
+            echo "=== Cleaning up old images ==="
+            docker image prune -f
+
+            echo "=== Deploy complete ==="


### PR DESCRIPTION
Restructure and enhance GitHub Actions workflow: rename to CI/CD, restrict push triggers to main, and split pipeline into backend and frontend jobs. Upgrade tooling (actions/setup-node@v4, Node 22, postgres:15-alpine), add npm caching, set CI env vars (JWT_SECRET, NODE_ENV), run prisma migrate, lint/format checks, unit/E2E/coverage tests for backend, and use pnpm for frontend lint/tests. Add a deploy job that runs only on pushes to main to SSH into the VPS, pull, build and restart services via docker compose, and prune images.