### PR TITLE
feat(rwd): Ajuster la page statistiques RWD

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -172,6 +172,9 @@
     * {
         @apply border-border outline-ring/50;
     }
+    html {
+        @apply overflow-x-hidden;
+    }
     body {
         @apply bg-background text-foreground;
     }

--- a/frontend/components/charts/HoldingsPieChart.tsx
+++ b/frontend/components/charts/HoldingsPieChart.tsx
@@ -74,10 +74,7 @@ export function HoldingsPieChart() {
 
     return (
         <div className="relative w-full h-full flex flex-col">
-            <ChartContainer
-                config={chartConfig}
-                className="mx-auto aspect-square max-h-[350px] sm:max-h-[400px] lg:max-h-[450px] w-full"
-            >
+            <ChartContainer config={chartConfig} className="mx-auto aspect-square sm:max-h-[400px] lg:max-h-[450px] w-full">
                 <PieChart>
                     <defs>
                         {COLORS.map((color, index) => (
@@ -121,7 +118,7 @@ export function HoldingsPieChart() {
                         data={chartData}
                         dataKey="weight"
                         nameKey="name"
-                        innerRadius="60%"
+                        innerRadius="55%"
                         outerRadius="80%"
                         paddingAngle={2}
                         activeIndex={activeIndex}
@@ -154,13 +151,13 @@ export function HoldingsPieChart() {
                                             <tspan
                                                 x={viewBox.cx}
                                                 y={viewBox.cy}
-                                                className="fill-foreground text-xl sm:text-2xl md:text-3xl font-bold"
+                                                className="fill-foreground text-lg sm:text-xl md:text-2xl font-bold"
                                             >
                                                 {centerLabel.value}
                                             </tspan>
                                             <tspan
                                                 x={viewBox.cx}
-                                                y={(viewBox.cy || 0) + 25}
+                                                y={(viewBox.cy || 0) + 22}
                                                 className="fill-muted-foreground text-xs sm:text-sm"
                                             >
                                                 {centerLabel.label}

--- a/frontend/components/header/Header.tsx
+++ b/frontend/components/header/Header.tsx
@@ -9,9 +9,9 @@ import MarketOpenBadge from "../ui/market-status-badge"
 export function SiteHeader({ headerTitle: _headerTitle }: { headerTitle: ReactNode }) {
     return (
         <header className="relative z-50 flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
-            <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
-                <SidebarTrigger className="-ml-1" />
-                <Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />
+            <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6 overflow-hidden">
+                <SidebarTrigger className="-ml-1 shrink-0" />
+                <Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4 shrink-0" />
                 <Suspense fallback={<p>Chargement du status du marché...</p>}>
                     <MarketOpenBadge />
                 </Suspense>

--- a/frontend/components/statistics/StatsKpiCards.tsx
+++ b/frontend/components/statistics/StatsKpiCards.tsx
@@ -87,16 +87,18 @@ export function StatsKpiCards() {
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3">
             {kpis.map((kpi) => (
                 <Card key={kpi.label} className="relative overflow-hidden">
-                    <CardContent className="px-3">
-                        <div className="flex flex-col gap-1.5">
+                    <CardContent className="px-3 sm:px-4">
+                        <div className="flex flex-col gap-1.5 sm:gap-2">
                             <div className="flex items-center justify-between">
-                                <p className="text-[13px] text-muted-foreground leading-none">{kpi.label}</p>
-                                <div className={`rounded-md p-1.5 ${kpi.bg}`}>
-                                    <kpi.icon className={`size-3.5 ${kpi.color}`} />
+                                <p className="text-xs sm:text-[13px] text-muted-foreground leading-none">{kpi.label}</p>
+                                <div className={`rounded-md p-1 sm:p-1.5 ${kpi.bg}`}>
+                                    <kpi.icon className={`size-3.5 sm:size-4 ${kpi.color}`} />
                                 </div>
                             </div>
-                            <p className="text-base font-bold leading-tight">{kpi.value}</p>
-                            {kpi.subtitle && <p className={`text-[11px] leading-none ${kpi.subtitleColor}`}>{kpi.subtitle}</p>}
+                            <p className="text-sm sm:text-base font-bold leading-tight">{kpi.value}</p>
+                            {kpi.subtitle && (
+                                <p className={`text-[11px] sm:text-xs leading-none ${kpi.subtitleColor}`}>{kpi.subtitle}</p>
+                            )}
                         </div>
                     </CardContent>
                 </Card>


### PR DESCRIPTION
Tweak UI responsiveness and sizing across several components: prevent horizontal overflow by applying overflow-x-hidden globally; adjust HoldingsPieChart container class, reduce innerRadius from 60% to 55%, and scale down center label font sizes and vertical offset to improve fit; update header inner wrapper to hide overflow and mark SidebarTrigger/Separator as non-shrinking to stabilize layout; and make StatsKpiCards more responsive with adjusted padding, gaps, text/icon sizes and subtitle sizing for better small-screen appearance.